### PR TITLE
full_title helperの追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+
+    # ページごとの完全なタイトルを返す
+  def full_title(page_title = '')
+    base_title = "ToDo App"
+    if page_title.empty?
+      base_title
+    else
+      "#{page_title} | #{base_title}"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | ToDo App</title>
+  <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta charset="utf-8">
     <%= csrf_meta_tags %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,3 +1,2 @@
-<% provide(:title, "Home") %>
 <h1>ToDo App for learning</h1>
 <p>これは勉強用のToDoアプリです。</p>

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -14,7 +14,7 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home | #{@base_title}"
+    assert_select "title", "#{@base_title}"
   end
 
   test "should get about" do


### PR DESCRIPTION
application_helperにfull_titleヘルパーを追加しました。
これにより、タイトルが与えられなかった場合には"ToDo App"を、与えられた場合は"(与えられたタイトル名) | ToDo App"をタイトル欄に表示させるようにしました。
レビューよろしくお願いします。
PRの書き方も少しずつ洗練させていきたいと考えています。